### PR TITLE
Proposal: use VERCEL env variable

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -6,7 +6,7 @@ module.exports = {
   // When running locally in development mode, we use the built in remix
   // server. This does not understand the vercel lambda module format,
   // so we default back to the standard build output.
-  server: process.env.NODE_ENV === 'development' ? undefined : './server.js',
+  server: process.env.VERCEL ? './server.js' : undefined,
   ignoredRouteFiles: ['**/.*'],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",


### PR DESCRIPTION
See https://vercel.com/docs/concepts/projects/environment-variables

It's probably safer to use this variable, because you may want to run your built app locally as well:
- in dev no problem
- build + start locally => use default remix behaviour
- build + start locally with setting VERCEL=1 => use Vercel behaviour
- build + start on vercel => use Vercel behaviour

It makes it possible to test all scenario while your setup do not allow scenario 2 in this list